### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/E-Emad/devops-capstone-project/security/code-scanning/1](https://github.com/E-Emad/devops-capstone-project/security/code-scanning/1)

The best way to fix this problem is to add a `permissions` block specifying the least privilege required, somewhere that covers all jobs. In this workflow, the job does not appear to require write access to any part of the repository; it only checks out code, installs dependencies, runs linting, and runs tests. Therefore, setting `permissions: contents: read` at the workflow root provides sufficient (read-only) permissions for the GITHUB_TOKEN, applying to the entire workflow and all jobs. This should be added near the top of the file, underneath the `name` and `on` statements but before the `jobs` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
